### PR TITLE
Refactor WHERE/selection logic into shared helpers; add header/menu utilities

### DIFF
--- a/src/Delete.gs
+++ b/src/Delete.gs
@@ -1,28 +1,10 @@
 function deleteFrom(input) 
 {
- // input = "DELETE FROM test WHERE a = 1";
   var parse = simpleSqlParser.sql2ast(input);
   var table = parse["DELETE FROM"][0];
   var where = parse["WHERE"];
   var tableArray = getTableFromSheet_(table);
-  var rows = [];
-
-  if (where == null)
-  {
-    for (var i = 2; i < tableArray.length; i++)
-      rows.push(i);
-  }
-  else if (where["logic"] == null)
-  {
-    var attr = where["left"];
-    var operator = where["operator"];
-    var value = where["right"];
-    rows = dSelect(tableArray, attr, operator, value);
-  }
-  else 
-  {
-    rows = dWhere(tableArray, where);
-  }
+  var rows = resolveRowsFromWhere_(tableArray, where, dSelect);
   
   deleteHelp(table, rows);
 }
@@ -37,129 +19,20 @@ function deleteHelp(tableName, rows)
 
 function dWhere(tableArray, term)
 {
-  var logic = term["logic"];
-  var terms = term["terms"];
-  var term0 = terms[0];
-  var term1 = terms[1];
-  var rows0,rows1;
-  
-  if (term0["logic"] == null)
-  {
-    var attr = term0["left"];
-    var operator = term0["operator"];
-    var value = term0["right"];
-    rows0 = dSelect(tableArray, attr, operator, value);  
-  }
-  else
-  {
-    rows0 = dWhere(tableArray, term0);
-  }
-  if (term1["logic"] == null)
-  {
-    var attr = term1["left"];
-    var operator = term1["operator"];
-    var value = term1["right"];
-    rows1 = dSelect(tableArray, attr, operator, value);  
-  }
-  else
-  {
-    rows1 = dWhere(tableArray, term1);
-  }
-  
-  if (logic == "AND")
-  {
-    return dIntersect(rows0, rows1);
-  }
-  else if (logic == "OR")
-  {
-    return dUnion(rows0, rows1);
-  }
-  
+  return resolveRowsByLogic_(tableArray, term, dSelect);
 }
 
 function dIntersect(rows0, rows1)
 {
-
-  var i = 0, j = 0;
-  var out = [];
-  while (i < rows0.length && j < rows1.length)
-  {
-    if (rows0[i] < rows1[j])
-      i++;
-    else if (rows0[i] > rows1[j])
-      j++;
-    else 
-    {
-      out.push(rows0[i]);
-      i++;
-      j++;
-    }
-  }
-  return out;
+  return intersectSortedRows_(rows0, rows1);
 }
 
 function dUnion(rows0, rows1)
 {
-  var i = 0, j = 0;
-  while (j < rows1.length)
-  {
-    if (rows0[i] < rows1[j])
-    {  
-      i++;
-      if (i == rows0.length)
-      {
-        rows0 = rows0.concat(rows1.slice(j));
-        break;
-      }
-    }
-    else if (rows0[i] > rows1[j])
-    {
-      rows0.splice(i,0, rows1[j]);
-      i++;
-      j++;
-    }
-    else 
-    {
-      i++;
-      j++;
-    }
-  }
-  return rows0;
+  return unionSortedRows_(rows0, rows1);
 }
 
 function dSelect(inputRange, attribute, operator, value)
 {
-  var data =  inputRange;
-
-  /* Get the index for the attribute, to be used later on */  
-  var attribute_idx = findInArray_(data[1], attribute);
-  if (attribute_idx == -1)
-    throw "Invalid attribute : " + attribute;
-  
-  /* Validate the operator */
-  if (operator!="<" && operator!=">" && operator!="=" && operator!=">=" && operator!="<=")
-    throw "Invalid operator : " + operator;
-  
-  /* Array to gather the output of the operator */
-  var out=[];
-  
-  /* Copy the data that matches the condition */
-  for (var i = 2; i < data.length; i++) {
-    var match = false;
-    if (operator=="<")
-      match = data[i][attribute_idx] < value;
-    else if (operator==">")
-      match = data[i][attribute_idx] > value;
-    else if (operator==">=")
-      match = data[i][attribute_idx] >= value;
-    else if (operator=="<=")
-      match = data[i][attribute_idx] <= value;
-    else
-      match = data[i][attribute_idx] == value;
-    
-    /* If the tuple matches the condition append it to output */
-    if (match)
-      out.push(i);
-  }
-  return out;
+  return selectRowsByComparison_(inputRange, attribute, operator, value);
 }

--- a/src/SQL.gs
+++ b/src/SQL.gs
@@ -2,13 +2,18 @@ var SQL_SHEET_NAME = 'SQL';
 var SQL_SUCCESS_SUFFIX = ' success';
 var SQL_MENU_NAME = 'SQL';
 var SQL_MAX_QUERY_LENGTH = 50000;
+var SQL_MENU_ITEMS = [
+  {label: 'Show prompt', handler: 'showPrompt'},
+  {label: 'Clear History', handler: 'warning'}
+];
 
 function onOpen(e) {
   var ui = SpreadsheetApp.getUi();
-  ui.createMenu(SQL_MENU_NAME)
-      .addItem('Show prompt', 'showPrompt')
-      .addItem('Clear History', 'warning')
-      .addToUi();
+  var menu = ui.createMenu(SQL_MENU_NAME);
+  for (var i = 0; i < SQL_MENU_ITEMS.length; i++) {
+    menu.addItem(SQL_MENU_ITEMS[i].label, SQL_MENU_ITEMS[i].handler);
+  }
+  menu.addToUi();
 }
 
 function onInstall(e) {

--- a/src/Table.gs
+++ b/src/Table.gs
@@ -51,19 +51,18 @@ function alterTable(input)
     throw 'Invalid sheet : ' + tableName;
   }
 
-  if (operation == 'ADD')
+  if (operation === 'ADD')
   {
-    var c = 1;
-    var cell = sheet.getRange(1, c);
-    while (!cell.isBlank())
-    {
-      if (cell.getValue() == column)
+    var existingColumns = getHeaderValues_(sheet);
+    for (var i = 0; i < existingColumns.length; i++) {
+      if (existingColumns[i] === column) {
         throw 'The column already exists!';
-      c++;
-      cell = sheet.getRange(1, c);
+      }
     }
-    cell.setValue(column);
-    cell.setFontWeight('bold');
+    var nextColumnIndex = existingColumns.length + 1;
+    var headerCell = sheet.getRange(1, nextColumnIndex);
+    headerCell.setValue(column);
+    headerCell.setFontWeight('bold');
     return;
   }
 
@@ -92,14 +91,28 @@ function parseAttributeList_(rawAttrs) {
 }
 
 function getColumnIndex_(sheet, columnName) {
-  var c = 1;
-  var cell = sheet.getRange(1, c);
-  while (!cell.isBlank()) {
-    if (cell.getValue() == columnName) {
-      return c;
+  var headerValues = getHeaderValues_(sheet);
+  for (var i = 0; i < headerValues.length; i++) {
+    if (headerValues[i] === columnName) {
+      return i + 1;
     }
-    c++;
-    cell = sheet.getRange(1, c);
   }
   return -1;
+}
+
+function getHeaderValues_(sheet) {
+  var lastColumn = sheet.getLastColumn();
+  if (lastColumn < 1) {
+    return [];
+  }
+
+  var headers = sheet.getRange(1, 1, 1, lastColumn).getValues()[0];
+  var out = [];
+  for (var i = 0; i < headers.length; i++) {
+    if (headers[i] === '') {
+      break;
+    }
+    out.push(headers[i]);
+  }
+  return out;
 }

--- a/src/Update.gs
+++ b/src/Update.gs
@@ -4,24 +4,7 @@ function update(input) {
   var set = parse["SET"];
   var where = parse["WHERE"];
   var tableArray = getTableFromSheet_(table);
-  var rows = [];
-
-  if (where == null)
-  {
-    for (var i = 2; i < tableArray.length; i++)
-      rows.push(i);
-  }
-  else if (where["logic"] == null)
-  {
-    var attr = where["left"];
-    var operator = where["operator"];
-    var value = where["right"];
-    rows = uSelect(tableArray, attr, operator, value);
-  }
-  else 
-  {
-    rows = uWhere(tableArray, where);
-  }
+  var rows = resolveRowsFromWhere_(tableArray, where, uSelect);
   updateHelp(table, rows, set);
 }
 
@@ -48,130 +31,21 @@ function updateHelp(tableName, rows, set)
 
 function uWhere(tableArray, term)
 {
-  var logic = term["logic"];
-  var terms = term["terms"];
-  var term0 = terms[0];
-  var term1 = terms[1];
-  var rows0,rows1;
-  
-  if (term0["logic"] == null)
-  {
-    var attr = term0["left"];
-    var operator = term0["operator"];
-    var value = term0["right"];
-    rows0 = uSelect(tableArray, attr, operator, value);  
-  }
-  else
-  {
-    rows0 = uWhere(tableArray, term0);
-  }
-  if (term1["logic"] == null)
-  {
-    var attr = term1["left"];
-    var operator = term1["operator"];
-    var value = term1["right"];
-    rows1 = uSelect(tableArray, attr, operator, value);  
-  }
-  else
-  {
-    rows1 = uWhere(tableArray, term1);
-  }
-  
-  if (logic == "AND")
-  {
-    return uIntersect(rows0, rows1);
-  }
-  else if (logic == "OR")
-  {
-    return uUnion(rows0, rows1);
-  }
-  
+  return resolveRowsByLogic_(tableArray, term, uSelect);
 }
 
 function uIntersect(rows0, rows1)
 {
-
-  var i = 0, j = 0;
-  var out = [];
-  while (i < rows0.length && j < rows1.length)
-  {
-    if (rows0[i] < rows1[j])
-      i++;
-    else if (rows0[i] > rows1[j])
-      j++;
-    else 
-    {
-      out.push(rows0[i]);
-      i++;
-      j++;
-    }
-  }
-  return out;
+  return intersectSortedRows_(rows0, rows1);
 }
 
 function uUnion(rows0, rows1)
 {
-  var i = 0, j = 0;
-  while (j < rows1.length)
-  {
-    if (rows0[i] < rows1[j])
-    {  
-      i++;
-      if (i == rows0.length)
-      {
-        rows0 = rows0.concat(rows1.slice(j));
-        break;
-      }
-    }
-    else if (rows0[i] > rows1[j])
-    {
-      rows0.splice(i,0, rows1[j]);
-      i++;
-      j++;
-    }
-    else 
-    {
-      i++;
-      j++;
-    }
-  }
-  return rows0;
+  return unionSortedRows_(rows0, rows1);
 }
 
 
 function uSelect(inputRange, attribute, operator, value)
 {
-  var data =  inputRange;
-
-  /* Get the index for the attribute, to be used later on */  
-  var attribute_idx = findInArray_(data[1], attribute);
-  if (attribute_idx == -1)
-    throw "Invalid attribute : " + attribute;
-  
-  /* Validate the operator */
-  if (operator!="<" && operator!=">" && operator!="=" && operator!=">=" && operator!="<=")
-    throw "Invalid operator : " + operator;
-  
-  /* Array to gather the output of the operator */
-  var out=[];
-  
-  /* Copy the data that matches the condition */
-  for (var i = 2; i < data.length; i++) {
-    var match = false;
-    if (operator=="<")
-      match = data[i][attribute_idx] < value;
-    else if (operator==">")
-      match = data[i][attribute_idx] > value;
-    else if (operator==">=")
-      match = data[i][attribute_idx] >= value;
-    else if (operator=="<=")
-      match = data[i][attribute_idx] <= value;
-    else
-      match = data[i][attribute_idx] == value;
-    
-    /* If the tuple matches the condition append it to output */
-    if (match)
-      out.push(i);
-  }
-  return out;
+  return selectRowsByComparison_(inputRange, attribute, operator, value);
 }

--- a/src/Where.gs
+++ b/src/Where.gs
@@ -1,0 +1,125 @@
+var SQL_VALID_COMPARISON_OPERATORS = ['<', '>', '=', '>=', '<='];
+
+function resolveRowsFromWhere_(tableArray, where, rowSelector) {
+  if (where == null) {
+    return getAllDataRowIndexes_(tableArray);
+  }
+
+  if (where.logic == null) {
+    return rowSelector(tableArray, where.left, where.operator, where.right);
+  }
+
+  return resolveRowsByLogic_(tableArray, where, rowSelector);
+}
+
+function resolveRowsByLogic_(tableArray, term, rowSelector) {
+  var logic = term.logic;
+  var terms = term.terms;
+  var leftTerm = terms[0];
+  var rightTerm = terms[1];
+  var rowsLeft = leftTerm.logic == null ?
+      rowSelector(tableArray, leftTerm.left, leftTerm.operator, leftTerm.right) :
+      resolveRowsByLogic_(tableArray, leftTerm, rowSelector);
+  var rowsRight = rightTerm.logic == null ?
+      rowSelector(tableArray, rightTerm.left, rightTerm.operator, rightTerm.right) :
+      resolveRowsByLogic_(tableArray, rightTerm, rowSelector);
+
+  if (logic === 'AND') {
+    return intersectSortedRows_(rowsLeft, rowsRight);
+  }
+  if (logic === 'OR') {
+    return unionSortedRows_(rowsLeft, rowsRight);
+  }
+
+  throw 'Invalid logic operator : ' + logic;
+}
+
+function getAllDataRowIndexes_(tableArray) {
+  var rows = [];
+  for (var rowIndex = 2; rowIndex < tableArray.length; rowIndex++) {
+    rows.push(rowIndex);
+  }
+  return rows;
+}
+
+function selectRowsByComparison_(inputRange, attribute, operator, value) {
+  var data = inputRange;
+  var attributeIndex = findInArray_(data[1], attribute);
+  if (attributeIndex === -1) {
+    throw 'Invalid attribute : ' + attribute;
+  }
+
+  if (!isValidComparisonOperator_(operator)) {
+    throw 'Invalid operator : ' + operator;
+  }
+
+  var outputRows = [];
+  for (var i = 2; i < data.length; i++) {
+    if (evaluateComparison_(data[i][attributeIndex], operator, value)) {
+      outputRows.push(i);
+    }
+  }
+  return outputRows;
+}
+
+function isValidComparisonOperator_(operator) {
+  return findInArray_(SQL_VALID_COMPARISON_OPERATORS, operator) !== -1;
+}
+
+function evaluateComparison_(leftValue, operator, rightValue) {
+  if (operator === '<') {
+    return leftValue < rightValue;
+  }
+  if (operator === '>') {
+    return leftValue > rightValue;
+  }
+  if (operator === '>=') {
+    return leftValue >= rightValue;
+  }
+  if (operator === '<=') {
+    return leftValue <= rightValue;
+  }
+  return leftValue == rightValue;
+}
+
+function intersectSortedRows_(rows0, rows1) {
+  var i = 0;
+  var j = 0;
+  var out = [];
+  while (i < rows0.length && j < rows1.length) {
+    if (rows0[i] < rows1[j]) {
+      i++;
+    } else if (rows0[i] > rows1[j]) {
+      j++;
+    } else {
+      out.push(rows0[i]);
+      i++;
+      j++;
+    }
+  }
+  return out;
+}
+
+function unionSortedRows_(rows0, rows1) {
+  var output = rows0.slice();
+  var i = 0;
+  var j = 0;
+  while (j < rows1.length) {
+    if (i >= output.length) {
+      output = output.concat(rows1.slice(j));
+      break;
+    }
+
+    if (output[i] < rows1[j]) {
+      i++;
+    } else if (output[i] > rows1[j]) {
+      output.splice(i, 0, rows1[j]);
+      i++;
+      j++;
+    } else {
+      i++;
+      j++;
+    }
+  }
+  return output;
+}


### PR DESCRIPTION
### Motivation
- Remove duplicated row-selection and boolean-logic code across `Delete.gs` and `Update.gs` by centralizing WHERE handling and comparison logic.
- Improve maintainability by extracting intersection/union and comparison evaluation into named helper functions.
- Simplify header and menu handling to make column lookups and UI construction clearer.

### Description
- Add `Where.gs` containing `resolveRowsFromWhere_`, `resolveRowsByLogic_`, `selectRowsByComparison_`, `intersectSortedRows_`, `unionSortedRows_`, `getAllDataRowIndexes_`, and comparison helpers to consolidate WHERE/selection behavior.
- Update `Delete.gs` and `Update.gs` to use `resolveRowsFromWhere_` and the new selection helpers instead of in-file duplicated implementations, and to delegate `dSelect`/`uSelect`/`dWhere`/`uWhere`/intersect/union to the new functions.
- Refactor `Table.gs` to add `getHeaderValues_`, use it in `getColumnIndex_`, and use strict equality checks in `alterTable` while simplifying header insertion logic.
- Refactor `SQL.gs` to declare `SQL_MENU_ITEMS` and build the UI menu from that array instead of calling `addItem` repeatedly.

### Testing
- Ran the repository's automated unit test suite against the changes and all tests passed.
- Ran static checks/linting on the modified files and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c0c13f98832cb705dbbe3e300839)